### PR TITLE
fix: prevent setEmoji recursion

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,8 @@ module.exports = class RawTextDisplayParser {
     }
 
     if (isDefaultEmoji) {
-      this.appendText(' ')
+      // appending while the cursor is before the word re-dispatches it forever
+      if (this.position === this.end) this.appendText(' ')
     } else if (emoji) {
       this.selectRange(this.start, this.end)
       this.appendText(emoji)

--- a/test/emoji.test.js
+++ b/test/emoji.test.js
@@ -154,6 +154,30 @@ test('ondefaultemoji can set display mark for default emoji (with trailing space
   ])
 })
 
+test('ondefaultemoji does not recurse when resync leaves cursor before an uncovered emoji word', (t) => {
+  const p = new Parser({
+    ondefaultemoji: (word) => {
+      // consumers only call setEmoji when the word resolves to a known emoji
+      if (word !== '😀') return
+      p.setEmoji(word, 'grinning', word, true)
+    }
+  })
+
+  p.resync('x😀')
+  p.resync('a 😀')
+
+  t.is(p.text, 'a 😀')
+  t.alike(p.display, [
+    {
+      type: DISPLAY_TYPES.EMOJI,
+      start: 2,
+      end: 2 + '😀'.length,
+      content: 'grinning',
+      length: '😀'.length
+    }
+  ])
+})
+
 test('setEmoji normally then type in middle to remove it', (t) => {
   const p = new Parser()
 


### PR DESCRIPTION
https://app.asana.com/1/45238840754660/project/1216172615294031/task/1216470482566119?focus=true

`Maximum call stack size exceeded` issue handling

**Fix:** only append the space when the cursor is at the end of the emoji word (`this.position === this.end`); the display entry is still registered.